### PR TITLE
Improve the performance of .fire by not cloning the subscriber list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscribableevent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple strongly-typed pub/sub/fire eventing system",
   "author": "ReactXP Team <reactxp@microsoft.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "type": "git",
     "url": "git+https://github.com/Microsoft/SubscribableEvent.git"
   },
-  "dependencies": {
-    "lodash": "^4.17.0"
-  },
   "devDependencies": {
     "@types/jasmine": "2.8.8",
     "@types/lodash": "4.14.111",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-node": "7.0.0",
     "tslint": "5.10.0",
     "tslint-microsoft-contrib": "5.0.3",
-    "typescript": "2.9.2"
+    "typescript": "3.0.1"
   },
   "types": "dist-types/SubscribableEvent.d.ts"
 }

--- a/src/SubscribableEvent.ts
+++ b/src/SubscribableEvent.ts
@@ -41,7 +41,7 @@ export default class SubscribableEvent<F extends { (...args: any[]): boolean|voi
     }
 
     fire: F = <any> ((...args: any[]) => {
-        // Keep reference to the original readonly array, sWe don't want to have it change while we're firing
+        // Keep reference to the original readonly array. We don't want to have it change while we're firing
         const subs = this._subscribers;
 
         // Execute handlers in the reverse order in which they were registered.


### PR DESCRIPTION
Instead create a new list of subscribers when calling subscribe or unsubscribe
use ReadOnlyArray which gives us confidence (via TS compiler) that no mutations will occur to the array